### PR TITLE
Use `code` instead of `artifacts` for code to AMR

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -98,21 +98,21 @@ def equations_to_amr(
 
 @app.post("/code_to_amr")
 def code_to_amr(
-    artifact_id: str, name: Optional[str] = None, description: Optional[str] = None, redis=Depends(get_redis)
+    code_id: str, name: Optional[str] = None, description: Optional[str] = None, redis=Depends(get_redis)
 ) -> ExtractionJob:
     """
-    Converts a code artifact to an AMR. Assumes that the code file is the first
-    file (and only) attached to the artifact.
+    Converts a code object to an AMR. Assumes that the code file is the first
+    file (and only) attached to the code.
 
     Args:
     ```
-        artifact_id (str): the id of the code artifact
+        code_id (str): the id of the code
         name (str, optional): the name to set on the newly created model
         description (str, optional): the description to set on the newly created model
     ```
     """
     operation_name = "operations.code_to_amr"
-    options = {"artifact_id": artifact_id, "name": name, "description": description}
+    options = {"code_id": code_id, "name": name, "description": description}
 
     resp = create_job(operation_name=operation_name, options=options, redis=redis)
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -28,7 +28,7 @@ logging.getLogger().setLevel(numeric_level)
 
 # REDIS CONNECTION AND QUEUE OBJECTS
 def get_redis():
-    redis = Redis(
+    return Redis(
         settings.REDIS_HOST,
         settings.REDIS_PORT,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,7 @@ def gen_tds_artifact(context_dir, http_mock, file_storage):
         }
         if code:
             artifact["filename"] = "code.py"
+            artifact["language"] = "python"
         else:
             artifact["file_names"]: []
         artifact_url = f"{settings.TDS_URL}/{_type}/{artifact['id']}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,16 +114,20 @@ def file_storage(http_mock):
 def gen_tds_artifact(context_dir, http_mock, file_storage):
     # Mock the TDS artifact
     counter = count()
-    def generate():
+    def generate(code=False):
+        if code:
+            _type = "code"
+        else:
+            _type = "artifacts"
         artifact = {
-            "id": f"artifact-{next(counter)}",
-            "name": "artifact",
-            "description": "test artifact",
+            "id": f"{_type}-{next(counter)}",
+            "name": _type,
+            "description": f"test {_type}",
             "timestamp": "2023-07-17T19:11:43",
             "file_names": [],
             "metadata": {},
         }
-        artifact_url = f"{settings.TDS_URL}/artifacts/{artifact['id']}"
+        artifact_url = f"{settings.TDS_URL}/{_type}/{artifact['id']}"
         http_mock.get(artifact_url, json=artifact)
         http_mock.put(artifact_url)
         return artifact

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,9 +124,12 @@ def gen_tds_artifact(context_dir, http_mock, file_storage):
             "name": _type,
             "description": f"test {_type}",
             "timestamp": "2023-07-17T19:11:43",
-            "file_names": [],
             "metadata": {},
         }
+        if code:
+            artifact["filename"] = "code.py"
+        else:
+            artifact["file_names"]: []
         artifact_url = f"{settings.TDS_URL}/{_type}/{artifact['id']}"
         http_mock.get(artifact_url, json=artifact)
         http_mock.put(artifact_url)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -94,12 +94,12 @@ def test_pdf_to_text(context_dir, http_mock, client, worker, gen_tds_artifact, f
 def test_code_to_amr(context_dir, http_mock, client, worker, gen_tds_artifact, file_storage):
     #### ARRANGE ####
     code = open(f"{context_dir}/code.py").read()
-    tds_artifact = gen_tds_artifact()
-    tds_artifact["file_names"] = ["code.py"]
+    tds_code = gen_tds_artifact(code=True)
+    tds_code["file_names"] = ["code.py"]
     file_storage.upload("code.py", code)
 
     query_params = {
-        "artifact_id": tds_artifact["id"],
+        "code_id": tds_code["id"],
         "name": "test model",
         "description": "test description",
     }

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -454,7 +454,7 @@ def code_to_amr(*args, **kwargs):
     code_amr_workflow_url = f"{UNIFIED_API}/workflows/code/snippets-to-pn-amr"
 
     request_payload = {
-        "files": [code_json.get("file_names")[0]],
+        "files": [code_json.get("filename")],
         "blobs": [code_blob],
     }
 
@@ -478,14 +478,15 @@ def code_to_amr(*args, **kwargs):
 
     if amr_response.status_code == 200 and amr_json:
         tds_responses = put_amr_to_tds(amr_json, name, description)
+        logger.info(f"TDS Response: {tds_responses}")
 
         put_artifact_extraction_to_tds(
             artifact_id=code_id,
             name=code_json.get("name", None),
-            filename=code_json.get("file_names")[0],
+            filename=code_json.get("filename"),
             description=code_json.get("description", None),
             model_id=tds_responses.get("model_id"),
-            code=True
+            code_language=code_json.get("language")
         )
 
         try:

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -443,23 +443,23 @@ def link_amr(*args, **kwargs):
 
 # 60e539e4-6969-4369-a358-c601a3a583da
 def code_to_amr(*args, **kwargs):
-    artifact_id = kwargs.get("artifact_id")
+    code_id = kwargs.get("code_id")
     name = kwargs.get("name")
     description = kwargs.get("description")
 
-    artifact_json, downloaded_artifact = get_artifact_from_tds(artifact_id=artifact_id)
+    code_json, downloaded_code = get_artifact_from_tds(code_id, code=True)
 
-    code_blob = downloaded_artifact.decode("utf-8")
+    code_blob = downloaded_code.decode("utf-8")
     logger.info(code_blob[:250])
     code_amr_workflow_url = f"{UNIFIED_API}/workflows/code/snippets-to-pn-amr"
 
     request_payload = {
-        "files": [artifact_json.get("file_names")[0]],
+        "files": [code_json.get("file_names")[0]],
         "blobs": [code_blob],
     }
 
     logger.info(
-        f"Sending code to TA1 service with artifact id: {artifact_id} at {code_amr_workflow_url}"
+        f"Sending code to TA1 service with code id: {code_id} at {code_amr_workflow_url}"
     )
     amr_response = requests.post(
         code_amr_workflow_url, json=json.loads(json.dumps(request_payload))
@@ -480,24 +480,25 @@ def code_to_amr(*args, **kwargs):
         tds_responses = put_amr_to_tds(amr_json, name, description)
 
         put_artifact_extraction_to_tds(
-            artifact_id=artifact_id,
-            name=artifact_json.get("name", None),
-            filename=artifact_json.get("file_names")[0],
-            description=artifact_json.get("description", None),
+            artifact_id=code_id,
+            name=code_json.get("name", None),
+            filename=code_json.get("file_names")[0],
+            description=code_json.get("description", None),
             model_id=tds_responses.get("model_id"),
+            code=True
         )
 
         try:
             set_provenance(
                 tds_responses.get("model_id"),
                 "Model",
-                artifact_id,
-                "Artifact",
+                code_id,
+                "Code",
                 "EXTRACTED_FROM",
             )
         except Exception as e:
             logger.error(
-                f"Failed to store provenance tying model to code artifact: {e}"
+                f"Failed to store provenance tying model to code: {e}"
             )
 
         response = {

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -448,7 +448,7 @@ def code_to_amr(*args, **kwargs):
     description = kwargs.get("description")
 
     code_json, downloaded_code = get_artifact_from_tds(code_id, code=True)
-
+    
     code_blob = downloaded_code.decode("utf-8")
     logger.info(code_blob[:250])
     code_amr_workflow_url = f"{UNIFIED_API}/workflows/code/snippets-to-pn-amr"
@@ -477,6 +477,9 @@ def code_to_amr(*args, **kwargs):
         logger.error(f"Failed to parse response from TA1 Service:\n{amr_response.text}")
 
     if amr_response.status_code == 200 and amr_json:
+        metadata = amr_json.get("metadata",{})
+        metadata["code_id"] = code_id
+        amr_json["metadata"] = metadata
         tds_responses = put_amr_to_tds(amr_json, name, description)
         logger.info(f"TDS Response: {tds_responses}")
 


### PR DESCRIPTION
# Implements `code` objects

This PR swaps out `artifacts` for `code` objects in TDS for the `/code_to_amr` endpoint. It also adds the `code_id` to the `model` metadata so that it can more readily be traced back to its source code without a `provenance` call. 

Closes #21 