### PR TITLE
Worker utils changes to always create a config in TDS.

### DIFF
--- a/worker/utils.py
+++ b/worker/utils.py
@@ -42,7 +42,7 @@ def put_amr_to_tds(amr_payload, name=None, description=None, model_id=None):
 
     logger.debug(amr_payload)
 
-    # Create TDS model
+    # Update model if it exists in TDS already.
     if model_id:
         tds_models = f"{TDS_API}/models/{model_id}"
         model_response = requests.put(tds_models, json=amr_payload, headers=headers)
@@ -51,7 +51,7 @@ def put_amr_to_tds(amr_payload, name=None, description=None, model_id=None):
                 f"Cannot update model {model_id} in TDS with payload:\n\n {amr_payload}"
             )
         logger.info(f"Updated model in TDS with id {model_id}")
-        # return {"model_id": model_id}
+    # Create TDS model
     else:
         tds_models = f"{TDS_API}/models"
         model_response = requests.post(tds_models, json=amr_payload, headers=headers)
@@ -62,20 +62,16 @@ def put_amr_to_tds(amr_payload, name=None, description=None, model_id=None):
 
     # Create TDS model configuration
     tds_model_configurations = TDS_API + "/model_configurations"
+    header = amr_payload.get("header", {})
     configuration_payload = {
         "model_id": model_id,
-        "name": amr_payload.get("name")
-        if amr_payload.get("name") is not None
-        else amr_payload.get("header").get("name"),
-        "description": amr_payload.get("description")
-        if amr_payload.get("description") is not None
-        else amr_payload.get("header").get("description"),
-        "model_version": amr_payload.get("model_version")
-        if amr_payload.get("model_version") is not None
-        else amr_payload.get("header").get("model_version"),
+        "name": header.get("name", amr_payload.get("name")),
+        "description": header.get("description", amr_payload.get("description")),
+        "model_version": header.get("model_version", amr_payload.get("model_version")),
         "calibrated": False,
         "configuration": json.loads(json.dumps(amr_payload)),
     }
+
     config_response = requests.post(
         tds_model_configurations,
         data=json.dumps(configuration_payload, default=str),


### PR DESCRIPTION
# Description

* Moved the configuration creation to always happen at the end of the `put_amr_to_tds` process.
* Changed how configuration name and description are initialized to make it more consistent (since they are required by TDS).

Resolves #43 
