### PR TITLE
Link `AMR` and extractions

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -218,7 +218,6 @@ def profile_model(model_id: str, document_id: str, redis=Depends(get_redis)) -> 
 
 @app.post("/link_amr")
 def link_amr(document_id: str, model_id: str, redis=Depends(get_redis)) -> ExtractionJob:
-    raise HTTPException(status_code=501, detail="Endpoint is under development")
 
     operation_name = "operations.link_amr"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,7 @@ def gen_tds_artifact(context_dir, http_mock, file_storage):
             http_mock.put(artifact_url)
         else:
             result = requests.post(f"{settings.TDS_URL}/{_type}", json=artifact)
+            artifact['id'] = result.json()['id']
             if result.status_code >= 400:
                 raise requests.HTTPError("Error adding generated artifact to TDS")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,6 +149,24 @@ def gen_tds_artifact(context_dir, http_mock, file_storage):
         return artifact
     return generate
 
+@pytest.fixture
+def gen_tds_model(context_dir, http_mock):
+    # Mock the TDS artifact
+    counter = count()
+    def generate(model_id=None, amr=None):
+        if settings.MOCK_TDS:
+            models_url = f"{settings.TDS_URL}/models"
+            http_mock.post(models_url, json={"id": model_id})
+        else:
+            result = requests.post(f"{settings.TDS_URL}/models", json=amr)
+            if result.status_code >= 400:
+                raise requests.HTTPError("Error adding generated artifact to TDS")
+            else:
+                model_id = result.json()['id']
+
+        return model_id
+    return generate
+
 @pytest.mark.tryfirst
 def pytest_runtest_protocol(item, nextitem):
     """

--- a/tests/resources.yaml
+++ b/tests/resources.yaml
@@ -17,3 +17,6 @@ profile_model:
   - paper.pdf
   - code.py
   - amr.json
+link_amr:
+  - extractions.json
+  - amr.json

--- a/tests/resources.yaml
+++ b/tests/resources.yaml
@@ -18,5 +18,6 @@ profile_model:
   - code.py
   - amr.json
 link_amr:
+  - paper.pdf
   - extractions.json
   - amr.json

--- a/tests/scenarios/basic/config.yaml
+++ b/tests/scenarios/basic/config.yaml
@@ -8,3 +8,4 @@ enabled:
   - equations_to_amr
   - profile_dataset
   - profile_model
+  - link_amr

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -420,6 +420,8 @@ def test_link_amr(
         metadata=extractions
     )
 
+    file_storage.upload("paper.pdf", "TEST PDF")
+
     # overwrite model_id with the response in case TDS is NOT mocked and we get
     # back a real model ID
     model_id = gen_tds_model(model_id=model_id, amr=amr)    

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -419,8 +419,9 @@ def test_link_amr(
         file_names=["paper.pdf"],
         metadata=extractions
     )
-
-    file_storage.upload("paper.pdf", "TEST PDF")
+    
+    pdf = open(f"{context_dir}/paper.pdf", "rb")
+    file_storage.upload("paper.pdf", pdf)
 
     # overwrite model_id with the response in case TDS is NOT mocked and we get
     # back a real model ID

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -400,3 +400,64 @@ def test_profile_model(
     assert (
         status_response.json().get("status") == "finished"
     ), f"The RQ job failed.\n{job.latest_result().exc_string}"
+
+
+@pytest.mark.parametrize("resource", params["link_amr"])
+def test_link_amr(
+    context_dir, http_mock, client, worker, gen_tds_artifact, gen_tds_model, file_storage, resource
+):
+    #### ARRANGE ####
+    extractions = json.load(open(f"{context_dir}/extractions.json"))
+    amr = json.load(open(f"{context_dir}/amr.json"))
+    model_id = "test_model"
+    document_id = f"test_link_amr_document_{resource}"
+
+    # TODO: if TDS is NOT mocked, how do we know the ID of the document
+    # that is generated?
+    document = gen_tds_artifact(
+        id=document_id,
+        file_names=["paper.pdf"],
+        metadata=extractions
+    )
+
+    # overwrite model_id with the response in case TDS is NOT mocked and we get
+    # back a real model ID
+    model_id = gen_tds_model(model_id=model_id, amr=amr)    
+
+    if settings.MOCK_TDS:
+        http_mock.get(
+            f"{settings.TDS_URL}/models/{model_id}", json=amr
+        )
+        http_mock.get(
+            f"{settings.TDS_URL}/documents/{document_id}", json=document
+        )        
+        http_mock.put(f"{settings.TDS_URL}/models/{model_id}", json={"id": model_id})
+
+    if settings.MOCK_TA1:
+        http_mock.post(
+            f"{settings.TA1_UNIFIED_URL}/metal/link_amr",
+            json=amr,
+        )
+
+    query_params = {
+        "model_id": model_id,
+        "document_id": document_id
+    }
+
+    #### ACT ####
+    response = client.post(
+        "/link_amr",
+        params=query_params,
+        headers={"Content-Type": "application/json"},
+    )
+    results = response.json()
+    job_id = results.get("id")
+    worker.work(burst=True)
+    status_response = client.get(f"/status/{job_id}")
+
+    #### ASSERT ####
+    assert results.get("status") == "queued"
+    assert status_response.status_code == 200
+    assert (
+        status_response.json().get("status") == "finished"
+    ), f"The RQ job failed.\n{job.latest_result().exc_string}"

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -478,25 +478,26 @@ def link_amr(*args, **kwargs):
 
     extractions = document_json.get('metadata',{})
 
-    tds_models_url = f"{TDS_API}/models/{model_id}"
+    tds_model_url = f"{TDS_API}/models/{model_id}"
 
-    model = requests.get(tds_models_url)
+    model = requests.get(tds_model_url)
     model_json = model.json()
     model_amr = model_json.get("model")
 
     logging.debug(model_amr)
 
-    jsonified_amr = json.dumps(model_amr).encode("utf-8")
+    stringified_amr = json.dumps(model_amr).encode("utf-8")
+    stringified_extractions = json.dumps(extractions).encode("utf-8")
 
     files = {
         "amr_file": (
             "amr.json",
-            io.BytesIO(jsonified_amr),
+            io.BytesIO(stringified_amr),
             "application/json",
         ),
         "text_extractions_file": (
             "extractions.json",
-            io.BytesIO(extractions),
+            io.BytesIO(stringified_extractions),
             "application/json",
         ),
     }
@@ -511,8 +512,7 @@ def link_amr(*args, **kwargs):
     if response.status_code == 200:
         enriched_amr = response.json()
 
-        tds_models = f"{tds_models_url}/{model_id}"
-        model_response = requests.put(tds_models, json=enriched_amr)
+        model_response = requests.put(tds_model_url, json=enriched_amr)
         if model_response.status_code != 200:
             raise Exception(
                 f"Cannot update model {model_id} in TDS with payload:\n\n {enriched_amr}"


### PR DESCRIPTION
# Description

This PR adds a working `/link_amr` endpoint which takes in a `model_id` and a `document_id` and submits them to SKEMA for alignment. 

> Note: it assumes that the `document` has had extraction performed on it and that those extractions are available in its `metadata`.

This PR also includes some updates to the test suite to accommodate creation of a model during the preamble.

Resolves [#22](https://github.com/DARPA-ASKEM/knowledge-middleware/issues/22) 

## BLOCKED

SKEMA is having some issues so testing is not possible until [this is resolved](https://github.com/ml4ai/skema/issues/475)