### PR TITLE
feat: keep existing name/description when using equations to amr

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -195,11 +195,8 @@ def test_equations_to_amr(context_dir, http_mock, client, worker, file_storage):
     }
    
     mock_amr_header = {
-            "name": "Test SIR Model",
-            "schema": "petrinet_schema.json",
-            "description": "Test SIR model",
-            "schema_name": "petrinet",
-            "model_version": "0.1"
+            "name": "Test Existing SIR Model",
+            "description": "Test Existing SIR model"
         }
 
     if settings.MOCK_TDS:
@@ -253,6 +250,10 @@ def test_equations_to_amr(context_dir, http_mock, client, worker, file_storage):
     worker.work(burst=True)
     status_response = client.get(f"/status/{job_id}")
 
+    job2 = Job.fetch(job_id, connection=worker.connection)
+    if job2.result is not None:
+        amr_instance_2 = AMR(job2.result["amr"])    
+
     #### ASSERT ####
     # Case 1
     assert results.get("status") == "queued"
@@ -274,6 +275,7 @@ def test_equations_to_amr(context_dir, http_mock, client, worker, file_storage):
     assert status_config_response.status_code == 200
 
     assert storage[1].get("model_id") == "test2"
+    assert amr_instance_2.header["name"] == mock_amr_header["name"]
 
     #### POSTAMBLE ####
     # if 'amr' in locals():

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -193,12 +193,22 @@ def test_equations_to_amr(context_dir, http_mock, client, worker, file_storage):
         "name": "test model 2",
         "description": "test description 2",
     }
+   
+    mock_amr_header = {
+            "name": "Test SIR Model",
+            "schema": "petrinet_schema.json",
+            "description": "Test SIR model",
+            "schema_name": "petrinet",
+            "model_version": "0.1"
+        }
 
-    http_mock.post(f"{settings.TDS_URL}/models", json={"id": "test"})
-    http_mock.put(f"{settings.TDS_URL}/models/test2", json={"id": "test2"})
-    http_mock.post(
-        f"{settings.TDS_URL}/model_configurations", json=write_to_fake_configs
-    )
+    if settings.MOCK_TDS:
+        http_mock.post(f"{settings.TDS_URL}/models", json={"id": "test"})
+        http_mock.get(f"{settings.TDS_URL}/models/test2", json={"header": mock_amr_header})
+        http_mock.put(f"{settings.TDS_URL}/models/test2", json={"id": "test2"})
+        http_mock.post(
+            f"{settings.TDS_URL}/model_configurations", json=write_to_fake_configs
+        )
     if settings.MOCK_TA1:
         amr = json.load(open(f"{context_dir}/amr.json"))
         http_mock.post(

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -124,6 +124,7 @@ def skema_extraction(document_id, filename, downloaded_document):
 
     return text, response.status_code, extraction_json
 
+
 def cosmos_extraction(document_id, filename, downloaded_document, force_run=False):
     MAX_EXECTION_TIME = 600
     POLLING_INTERVAL = 5
@@ -523,7 +524,7 @@ def link_amr(*args, **kwargs):
 
         return {
             "status": model_response.status_code,
-            "amr": model_amr,            
+            "amr": model_amr,
             "message": "Model enriched and updated in TDS",
         }
     else:

--- a/worker/utils.py
+++ b/worker/utils.py
@@ -45,12 +45,22 @@ def put_amr_to_tds(amr_payload, name=None, description=None, model_id=None):
     # Update model if it exists in TDS already.
     if model_id:
         tds_models = f"{TDS_API}/models/{model_id}"
-        model_response = requests.put(tds_models, json=amr_payload, headers=headers)
-        if model_response.status_code != 200:
+
+				model_response = requests.get(tds_models, headers=headers)
+				if model_response.status_code != 200:
+					raise Exception(f"Cannot fetch model {model_id} in TDS")
+
+				# Keep name and information from existing model
+				amr_payload["header"]["name"] = model_response.content.name
+				amr_payload["header"]["description"] = model_response.content.description
+
+        update_model_response = requests.put(tds_models, json=amr_payload, headers=headers)
+        if update_model_response.status_code != 200:
             raise Exception(
                 f"Cannot update model {model_id} in TDS with payload:\n\n {amr_payload}"
             )
         logger.info(f"Updated model in TDS with id {model_id}")
+
     # Create TDS model
     else:
         tds_models = f"{TDS_API}/models"

--- a/worker/utils.py
+++ b/worker/utils.py
@@ -46,13 +46,14 @@ def put_amr_to_tds(amr_payload, name=None, description=None, model_id=None):
     if model_id:
         tds_models = f"{TDS_API}/models/{model_id}"
 
-				model_response = requests.get(tds_models, headers=headers)
-				if model_response.status_code != 200:
-					raise Exception(f"Cannot fetch model {model_id} in TDS")
+        model_response = requests.get(tds_models, headers=headers)
+        if model_response.status_code != 200:
+            raise Exception(f"Cannot fetch model {model_id} in TDS")
 
-				# Keep name and information from existing model
-				amr_payload["header"]["name"] = model_response.content.name
-				amr_payload["header"]["description"] = model_response.content.description
+        # Keep name and information from existing model
+        fetched_amr = model_response.json()
+        amr_payload["header"]["name"] = fetched_amr.get("header",{}).get("name", None)
+        amr_payload["header"]["description"] = fetched_amr.get("header",{}).get("description", None)
 
         update_model_response = requests.put(tds_models, json=amr_payload, headers=headers)
         if update_model_response.status_code != 200:


### PR DESCRIPTION
# Description

* When using Equation to AMR even if a `model_id` is provided, the AMR response from TA1 would overwrite the whole model.
* Keep the `header.name` and `header.description` that could be set before calling the method.