### PR TITLE
Ensure that cards are required in scenarios

### DIFF
--- a/tests/resources.yaml
+++ b/tests/resources.yaml
@@ -12,11 +12,13 @@ profile_dataset:
   - text.json
   - paper.pdf
   - data.csv
+  - data_card.json
 profile_model:
   - text.json
   - paper.pdf
   - code.py
   - amr.json
+  - model_card.json
 link_amr:
   - paper.pdf
   - extractions.json


### PR DESCRIPTION
`model_card.json` and `data_card.json` are used in the tests for data and model cards however they weren't listed as resources in `resource.yaml`