### PR TITLE
feat: update report to support local version

### DIFF
--- a/lib/settings.py
+++ b/lib/settings.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     AWS_ACCESS_KEY_ID: str = "NA"
     AWS_SECRET_ACCESS_KEY: str = "NA"
     BUCKET: str = "NA"
+    LIVE_SERVICES: bool = True
 
 
 settings = Settings()

--- a/tests/report.py
+++ b/tests/report.py
@@ -81,7 +81,9 @@ def gen_report():
     }
 
     timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
-    filename = f"report_{timestamp}.json"
+		# add a prefix to the filename if we're running local services
+		is_local = "" if settings.LIVE_SERVICES else "_local"
+    filename = f"report{is_local}_{timestamp}.json"
     fullpath = os.path.join("tests/output", filename)
     with open(fullpath, "w") as file:
         json.dump(report, file, indent=2)


### PR DESCRIPTION
# Description

* Add a `_local` to the report filename if an ENV `LIVE_SERVICES` is set to FALSE
* This allow to run the `knowledge-middleware-report` with different services.

See PRs
* https://github.com/DARPA-ASKEM/integration-dashboard/pull/4
* https://github.com/DARPA-ASKEM/orchestration/pull/300