### PR TITLE
Store raw extractions from SKEMA + logging updates

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -456,9 +456,9 @@ def test_profile_model(
     assert (
         status_response.json().get("status") == "finished"
     ), f"The RQ job failed.\n{job.latest_result().exc_string}"
-
     #### POSTAMBLE ####
     if not settings.MOCK_TA1 and os.path.exists(f"{context_dir}/ground_truth_model_card.json"):
+        logger.debug(f"Evaluating model card: {generated_card}")
         files = {
             "test_json_file": json.dumps(generated_card),
             "ground_truth_file": open(f"{context_dir}/ground_truth_model_card.json")
@@ -468,6 +468,7 @@ def test_profile_model(
             params={"gpt_key": settings.OPENAI_API_KEY},
             files=files
         )
+        logger.info(f"Model profiling evaluation result: {eval.text}")
         if eval.status_code < 300:
             accuracy = eval.json()["accuracy"]
         else:

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -362,23 +362,6 @@ def pdf_extractions(*args, **kwargs):
         )
         extraction_json = response.json()
         logger.debug(f"TA 1 response object: {response.text}")
-        outputs = extraction_json["outputs"]
-
-        if isinstance(outputs, dict):
-            if extraction_json.get("outputs", {"data": None}).get("data", None) is None:
-                raise ValueError(
-                    f"Malformed or empty response from backend knowledge service: {extraction_json}"
-                )
-            else:
-                extraction_json = extraction_json.get("outputs").get("data")
-        elif isinstance(outputs, list):
-            if extraction_json.get("outputs")[0].get("data") is None:
-                raise ValueError(
-                    f"Malformed or empty response from backend knowledge service: {extraction_json}"
-                )
-            else:
-                extraction_json = [extraction_json.get("outputs")[0].get("data")]
-                logging.info("HERE!")
 
     except ValueError:
         raise ValueError(f"Extraction for document {document_id} failed.")
@@ -608,8 +591,9 @@ def link_amr(*args, **kwargs):
     params = {"amr_type": "petrinet"}
 
     skema_amr_linking_url = f"{UNIFIED_API}/metal/link_amr"
-    logger.info(f"Sending model {model_id} and document {document_id} for linking")
+    logger.info(f"Sending model {model_id} and document {document_id} for linking to: {skema_amr_linking_url}")
     response = requests.post(skema_amr_linking_url, files=files, params=params)
+    logger.info(f"SKEMA response status code: {response.status_code}")
     logger.debug(f"TA 1 response object: {response.text}")
 
     if response.status_code == 200:

--- a/worker/utils.py
+++ b/worker/utils.py
@@ -109,10 +109,9 @@ def put_document_extraction_to_tds(
     Update an document or code object in TDS.
     """
     if extractions and text:
-        metadata = extractions[0]
-        # metadata["text"] = text
+        metadata = extractions
     elif extractions:
-        metadata = extractions[0]
+        metadata = extractions
     elif model_id:
         metadata = {"model_id": model_id}
     else:


### PR DESCRIPTION
Primarily this addresses #82 but also adds a bit better logging.

Note: since we do not parse SKEMA extractions it may impact some of the index mappings in staging/prod Elasticsearch. 

Also--I can't recall why we ever **_did parse that information_**; if there was some rational that actually mattered this PR will re-introduce that problem...