### PR TITLE
Configurations created from equations or code will be named "Default config"

### DIFF
--- a/worker/utils.py
+++ b/worker/utils.py
@@ -80,7 +80,7 @@ def put_amr_to_tds(amr_payload, name=None, description=None, model_id=None):
     header = amr_payload.get("header", {})
     configuration_payload = {
         "model_id": model_id,
-        "name": header.get("name", amr_payload.get("name")),
+        "name": "Default config",
         "description": header.get("description", amr_payload.get("description")),
         "model_version": header.get("model_version", amr_payload.get("model_version")),
         "calibrated": False,


### PR DESCRIPTION
Addresses #96 

@blanchco @pascaleproulx note that this will set the name of any config created (from equations OR code) to be named `Default config`.

If it should really only _just_ be for configs from equations let me know and I can make that tweak.