### PR TITLE
Store zipfile from Cosmos to S3

### DIFF
--- a/worker/utils.py
+++ b/worker/utils.py
@@ -108,6 +108,7 @@ def put_document_extraction_to_tds(
     text=None,
     model_id=None,
     assets=None,
+    zip_file_name=None
 ):
     """
     Update an document or code object in TDS.
@@ -126,7 +127,7 @@ def put_document_extraction_to_tds(
         "username": "extraction_service",
         "name": name,
         "description": description,
-        "file_names": [filename],
+        "file_names": [filename, zip_file_name],
         "text": text,
         "metadata": metadata,
         "assets": assets,


### PR DESCRIPTION
Addresses #116 

@YohannParis @Sorrento110 this PR takes the `.zip` from Cosmos and stores it to S3. Since we don't have a `document.asset.type` for the zipfile I just decided it would simplest to start by adding it as a `file` on the `document` canonically named `{document_id}_cosmos.zip`. E.g. if the `document` `id` is `abc123` the file is `abc123_cosmos.zip`.

So the document would have something like:

```
{
  "id": "2df851d1-f148-4ed8-8c81-a1ded8e59ba6",
  "name": "SIDARTHE - Lack of practical identifiability may hamper reliable predictions in COVID-19 epidemic models",
  "username": "extraction_service",
  "description": "string",
  "timestamp": "2023-10-18T01:51:38",
  "file_names": [
    "paper.pdf",
    "2df851d1-f148-4ed8-8c81-a1ded8e59ba6_cosmos.zip"
  ],
...
...
...
}
```

Let me know what you think.

Also-- @blanchco @YohannParis I confirmed the `document.asset.img_pth` does refer to the item on xDD which will be ephemeral. We could make the items public on S3 and replace that with an S3 URL, but it will be better to generate a pre-signed URL on the `document.asset.file_name`. Let me know if you have strong feelings one way or another. For clarity we might want to drop `document.asset.img_pth` since it's not really useful or persistent.