### PR TITLE
Added capability to specify scenarios in docker compose command.

### DIFF
--- a/reporting/README.md
+++ b/reporting/README.md
@@ -9,6 +9,7 @@ and trying to use a few requests through the relevant parts of the stack.
 - Create `reporting/.env` based off `env.sample` and change variables as needed
   - Set `UPLOAD=TRUE`, `BUCKET`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` IF you want the report uploaded
 - Run `docker compose run --build tests`. Once the `tests` container completes, the report is done.
+  - _Note:_ In order to run specific scenarios, you can specify them as follows: `docker compose run tests bash tests/run_tests.sh "<Scenario Directory>"` where the `<Scenario Directory>` the is full name of the directory containing all scenario files. You can specify as many as you would like in one run. _Example:_ `docker compose run tests bash tests/run_tests.sh "SIDARTHE Code" "SIDARTHE Equations" "SIR"`
 - View results using `docker compose run --build --service-ports dashboard` (Assuming you haven't deleted any volumes)
 
 Note: The services used in testing are not cleaned up following testing. When done with running tests,

--- a/reporting/README.md
+++ b/reporting/README.md
@@ -9,7 +9,7 @@ and trying to use a few requests through the relevant parts of the stack.
 - Create `reporting/.env` based off `env.sample` and change variables as needed
   - Set `UPLOAD=TRUE`, `BUCKET`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` IF you want the report uploaded
 - Run `docker compose run --build tests`. Once the `tests` container completes, the report is done.
-  - _Note:_ In order to run specific scenarios, you can specify them as follows: `docker compose run tests bash tests/run_tests.sh "<Scenario Directory>"` where the `<Scenario Directory>` the is full name of the directory containing all scenario files. You can specify as many as you would like in one run. _Example:_ `docker compose run tests bash tests/run_tests.sh "SIDARTHE Code" "SIDARTHE Equations" "SIR"`
+  - _Note:_ In order to run specific scenarios, you can specify them as follows: `docker compose run tests "<Scenario Directory>"` where the `<Scenario Directory>` the is full name of the directory containing all scenario files. You can specify as many as you would like in one run. _Example:_ `docker compose run tests "SIDARTHE Code" "SIDARTHE Equations" "SIR"`
 - View results using `docker compose run --build --service-ports dashboard` (Assuming you haven't deleted any volumes)
 
 Note: The services used in testing are not cleaned up following testing. When done with running tests,

--- a/reporting/tests/Dockerfile
+++ b/reporting/tests/Dockerfile
@@ -7,5 +7,4 @@ RUN pip install -r requirements.txt
 COPY scenarios scenarios/
 COPY tests tests/
 
-# CMD ["bash", "tests/run_tests.sh" , "&&", "while true; do sleep 1; done"]
 CMD [ "bash", "tests/run_tests.sh" ]

--- a/reporting/tests/Dockerfile
+++ b/reporting/tests/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install -r requirements.txt
 COPY scenarios scenarios/
 COPY tests tests/
 
-CMD [ "bash", "tests/run_tests.sh" ]
+ENTRYPOINT [ "bash", "tests/run_tests.sh" ]

--- a/reporting/tests/run_tests.sh
+++ b/reporting/tests/run_tests.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
 python tests/seed.py
-python tests/report.py
+# Check if there are additional arguments
+if [ $# -gt 0 ]; then
+    # Pass the additional arguments to the report.py script
+    python tests/report.py "$@"
+else
+    python tests/report.py
+fi


### PR DESCRIPTION
# Description

* You can pass in scenarios by name as strings into the docker compose command to run only specific ones.
* Updated README.

Resolves #111 

To test:
- Run the regular command and check the post-seeding logs, there should be an info line that says : `"Running pipeline on all scenarios"`. Feel free to kill that process after this.
- Run this command: `docker compose run tests bash tests/run_tests.sh "SIDARTHE Equations" "SIR" ` and check the post-seeding logs. There should be an info line that says: `"Running pipeline on scenarios: ['SIDARTHE Equations', 'SIR']"`
- Ensure that the specified scenarios run and no others (SIDARTHE Equations and SIR scenarios.)