### PR TITLE
fix: update worker operation arguments

### DIFF
--- a/worker/operations.py
+++ b/worker/operations.py
@@ -525,9 +525,9 @@ def data_card(*args, **kwargs):
     dataset_id = kwargs.get("dataset_id")
     document_id = kwargs.get("document_id")
 
-    if artifact_id:
-        document_json, downloaded_artifact = get_document_from_tds(
-            document_id=artifact_id
+    if document_id:
+        document_json, downloaded_document = get_document_from_tds(
+            document_id
         )
         doc_file = document_json.get(
             "text", "There is no documentation for this dataset"
@@ -550,7 +550,7 @@ def data_card(*args, **kwargs):
     }
 
     url = f"{MIT_API}/cards/get_data_card"
-    logger.info(f"Sending dataset {dataset_id} to MIT service at {url}")
+    logger.info(f"Sending dataset {dataset_id} and document {document_id} to MIT service at {url}")
     resp = requests.post(url, params=params, files=files)
     if resp.status_code != 200:
         raise Exception(f"Failed response from MIT: {resp.status_code}, {resp.text}")

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -523,7 +523,7 @@ def variable_extractions(*args, **kwargs):
 
 def data_card(*args, **kwargs):
     dataset_id = kwargs.get("dataset_id")
-    artifact_id = kwargs.get("artifact_id")
+    document_id = kwargs.get("document_id")
 
     if artifact_id:
         document_json, downloaded_artifact = get_document_from_tds(


### PR DESCRIPTION
* Looks like the api/server is sending a `document_id` argument, but the worker is expecting an `artifact_id`.
* This is the last reasons why the _Data profiling_ would not work, as the following works:
  * MIT service is functional - tested with their swagger
  * `data-service` is functional - the Document asset `4cd9ea66-38ab-4480-ac1a-d82c9cad840a` [has a text field](https://data-service.staging.terarium.ai/#/Project/create_asset_projects__project_id__assets__resource_type___resource_id__post)