### PR TITLE
Allow for specification of `ids` on model creation

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -78,7 +78,7 @@ def equations_to_amr(
         payload (List[str]): A list of LaTeX or MathML strings representing the functions that are used to convert to AMR
         equation_type (str): [latex, mathml]
         model (str, optional): AMR model return type. Defaults to "petrinet". Options: "regnet", "petrinet".
-        model_id (str, optional): the id of the model (to update) based on the set of equations
+        model_id (str, optional): the id of the model (to update/create) based on the set of equations
         name (str, optional): the name to set on the newly created model
         description (str, optional): the description to set on the newly created model
     ```
@@ -103,6 +103,7 @@ def equations_to_amr(
 def code_to_amr(
     code_id: str,
     name: Optional[str] = None,
+    model_id: Optional[str] = None,
     description: Optional[str] = None,
     dynamics_only: Optional[bool] = False,
     redis=Depends(get_redis),
@@ -115,6 +116,7 @@ def code_to_amr(
     ```
         code_id (str): the id of the code
         name (str, optional): the name to set on the newly created model
+        model_id (str, optional): the id of the model (to create) based on the code
         description (str, optional): the description to set on the newly created model
         dynamics_only (bool, optional): whether to only run the amr extraction over specified dynamics from the code object in TDS.
     ```
@@ -123,6 +125,7 @@ def code_to_amr(
     options = {
         "code_id": code_id,
         "name": name,
+        "model_id": model_id,
         "description": description,
         "dynamics_only": dynamics_only,
     }

--- a/reporting/tests/report.py
+++ b/reporting/tests/report.py
@@ -150,7 +150,7 @@ def standard_flow(scenario, _id):
     document_id = _id
     code_id = _id
     dataset_id = _id
-    model_id = None
+    model_id = _id
 
     def do_task(url, task, kwargs={}):
         return (task, run_km_job(url, scenario, task, kwargs))
@@ -228,11 +228,10 @@ def standard_flow(scenario, _id):
         yield non_applicable_run("code_to_amr")
     else:
         (task, result) = do_task(
-            url=f"{KM_URL}/code_to_amr?code_id={code_id}&dynamics_only=True&name={scenario}",
+            url=f"{KM_URL}/code_to_amr?code_id={code_id}&model_id={model_id}&dynamics_only=True&name={scenario}",
             task="code_to_amr",
         )
         if result["success"]:
-            model_id = result["result"]["job_result"]["tds_model_id"]
             add_asset(model_id, "models", project_id)
             add_provenance(left_id=model_id,
                            left_type="Model",
@@ -268,13 +267,12 @@ def standard_flow(scenario, _id):
                 "equation_type": equation_type,
             }
             (task, result) = do_task(
-                url=f"{KM_URL}/equations_to_amr?name={scenario}",
+                url=f"{KM_URL}/equations_to_amr?name={scenario}&model_id={model_id}",
                 task="equations_to_amr",
                 kwargs={"params": parameters_payload, "data": equations},
             )
 
             if result["success"]:
-                model_id = result["result"]["job_result"]["tds_model_id"]
                 add_asset(model_id, "models", project_id)
             else:
                 logging.error(

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -761,6 +761,7 @@ def link_amr(*args, **kwargs):
 def code_to_amr(*args, **kwargs):
     code_id = kwargs.get("code_id")
     name = kwargs.get("name")
+    model_id = kwargs.get("model_id")
     description = kwargs.get("description")
     dynamics_only = kwargs.get("dynamics_only", False)
 
@@ -834,7 +835,7 @@ def code_to_amr(*args, **kwargs):
         metadata = amr_json.get("metadata", {})
         metadata["code_id"] = code_id
         amr_json["metadata"] = metadata
-        tds_responses = put_amr_to_tds(amr_json, name, description)
+        tds_responses = put_amr_to_tds(amr_json, name, description, model_id)
         logger.info(f"TDS Response: {tds_responses}")
 
         put_code_extraction_to_tds(

--- a/worker/utils.py
+++ b/worker/utils.py
@@ -47,24 +47,22 @@ def put_amr_to_tds(amr_payload, name=None, description=None, model_id=None):
         tds_models = f"{TDS_API}/models/{model_id}"
 
         model_response = requests.get(tds_models, headers=headers)
-        if model_response.status_code != 200:
-            raise Exception(f"Cannot fetch model {model_id} in TDS")
-
-        # Keep name and information from existing model
-        fetched_amr = model_response.json()
-        amr_payload["header"]["name"] = fetched_amr.get("header", {}).get("name", None)
-        amr_payload["header"]["description"] = fetched_amr.get("header", {}).get(
-            "description", None
-        )
-
-        update_model_response = requests.put(
-            tds_models, json=amr_payload, headers=headers
-        )
-        if update_model_response.status_code != 200:
-            raise Exception(
-                f"Cannot update model {model_id} in TDS with payload:\n\n {amr_payload}"
+        if model_response.status_code == 200:
+            # Keep name and information from existing model
+            fetched_amr = model_response.json()
+            amr_payload["header"]["name"] = fetched_amr.get("header", {}).get("name", None)
+            amr_payload["header"]["description"] = fetched_amr.get("header", {}).get(
+                "description", None
             )
-        logger.info(f"Updated model in TDS with id {model_id}")
+
+            update_model_response = requests.put(
+                tds_models, json=amr_payload, headers=headers
+            )
+            if update_model_response.status_code != 200:
+                raise Exception(
+                    f"Cannot update model {model_id} in TDS with payload:\n\n {amr_payload}"
+                )
+            logger.info(f"Updated model in TDS with id {model_id}")
 
     # Create TDS model
     else:


### PR DESCRIPTION
Allow for `/code_to_amr` to optionally take a `model_id` to specify the `id` of the model upon creation. Patches the AMR creation utility to check if the model does not exist; if it exists the name/description are retained.