### PR TITLE
task: use public redis

### DIFF
--- a/reporting/docker-compose.yaml
+++ b/reporting/docker-compose.yaml
@@ -127,7 +127,7 @@ services:
       minio:
         condition: service_started
   redis:
-    image: ghcr.io/darpa-askem/redis:7.0.12-alpine
+    image: redis:7.0.12-alpine
     ports:
       - 6379
   knowledge-middleware-api:


### PR DESCRIPTION
Now that we are making all images public and this is a docker file, we can simply call the public redis image.
