### PR TITLE
Removed local TA1 containers and submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The Knowledge Middleware (`KM`) is designed to provide an intermediate job queue
 3. You can now run the tests or reports using the information below.
 4. You can also run `KM` with `make up`
 
+___Important Note:___ Running `make up` will target the regular `docker-compose.yaml` file. This file expects to be running with Terarium Data Service(TDS) on that same machine as it looks for a docker network set up by TDS. In order to run this stack standalone (pointing to a remote TDS installation) use the command `make up-prod`.
+
 ## Integration Testing
 `KM` provides a TA1 integration test harness that powers the [ASKEM Integration Dashboard](https://integration-dashboard.terarium.ai). It makes it easy to add new test cases and scenarios which will automatically be evaluated and surfaced in the dashboard. Additionally, the `KM` test harness can be run offline for development purposes. Running the `KM`` test harness requires docker compose. Please see [reporting/README.md](./reporting/README.md) for more information on how to run the test harness locally.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
   data-api:
     external: true
 services:
-  extraction-api:
+  api:
     container_name: api-knowledge-middleware
     build:
       context: ./
@@ -44,48 +44,6 @@ services:
     networks:
       - knowledge-middleware
       - data-api
-  mit-tr:
-    extends:
-      file: ./askem-ta1-dockervm/end-to-end-rest/docker-compose.yml
-      service: mit-tr
-    networks:
-      - knowledge-middleware
-  skema-tr:
-    extends:
-      file: ./askem-ta1-dockervm/end-to-end-rest/docker-compose.yml
-      service: skema-tr
-    networks:
-      - knowledge-middleware
-  skema-py:
-    extends:
-      file: ./askem-ta1-dockervm/end-to-end-rest/docker-compose.yml
-      service: skema-py
-    networks:
-      - knowledge-middleware
-  skema-rs:
-    extends:
-      file: ./askem-ta1-dockervm/end-to-end-rest/docker-compose.yml
-      service: skema-rs
-    networks:
-      - knowledge-middleware
-  graphdb:
-    extends:
-      file: ./askem-ta1-dockervm/end-to-end-rest/docker-compose.yml
-      service: graphdb
-    networks:
-      - knowledge-middleware
-  eq2mml:
-    extends:
-      file: ./askem-ta1-dockervm/end-to-end-rest/docker-compose.yml
-      service: eq2mml
-    networks:
-      - knowledge-middleware
-  mathjax:
-    extends:
-      file: ./askem-ta1-dockervm/end-to-end-rest/docker-compose.yml
-      service: mathjax
-    networks:
-      - knowledge-middleware
 
 volumes:
   mg_lib:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,8 +44,3 @@ services:
     networks:
       - knowledge-middleware
       - data-api
-
-volumes:
-  mg_lib:
-  mg_log:
-  mg_etc:

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -25,10 +25,10 @@ class Settings(BaseSettings):
     MOCK_TDS: bool = True
     REDIS_HOST: str = "redis.knowledge-middleware"
     REDIS_PORT: int = 6379
-    TA1_UNIFIED_URL: str = "http://ta1:5"
+    TA1_UNIFIED_URL: str = "https://api.askem.lum.ai"
     SKEMA_RS_URL: str = "http://skema-rs.staging.terarium.ai"
-    MIT_TR_URL: str = "http://mit:10"
-    TDS_URL: str = "http://tds:15"
+    MIT_TR_URL: str = "http://mit-tr.staging.terarium.ai"
+    TDS_URL: str = "http://data-service.staging.terarium.ai:8000"
     COSMOS_URL: str = "http://xdd.wisc.edu/cosmos_service"
     OPENAI_API_KEY: str = "foo"
     LOG_LEVEL: str = "INFO"


### PR DESCRIPTION
# Description
- Removed local TA1 containers from docker compose and removed the ta1 submodule. 
- Set URL constants in settings to reasonable defaults.

Resolves #133
