### PR TITLE
Provenance for AMR linking

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ networks:
   data-api:
     external: true
 services:
-  api:
+  km-api:
     container_name: api-knowledge-middleware
     build:
       context: ./

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -747,6 +747,18 @@ def link_amr(*args, **kwargs):
 
         model_amr.update(enriched_amr)
 
+        logger.info(f"Setting provenance between model {model_id} and document {document_id}")
+        try:
+            set_provenance(
+                model_id,
+                "Model",
+                document_id,
+                "Document",
+                "EXTRACTED_FROM",
+                )
+        except Exception as e:
+            logger.error(f"Failed to set provenance between model {model_id} and document {document_id}: {e}")
+
         return {
             "status": model_response.status_code,
             "amr": model_amr,


### PR DESCRIPTION
Addresses #172 by setting an `EXTRACTED_FROM` provenance tie between a `model` and the `document` it was enriched with.