### PR TITLE
Add support for LLM assisted code to AMR extraction

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -105,6 +105,7 @@ def code_to_amr(
     name: Optional[str] = None,
     model_id: Optional[str] = None,
     description: Optional[str] = None,
+    llm_assisted: Optional[bool] = True,    
     dynamics_only: Optional[bool] = False,
     redis=Depends(get_redis),
 ) -> ExtractionJob:
@@ -118,7 +119,8 @@ def code_to_amr(
         name (str, optional): the name to set on the newly created model
         model_id (str, optional): the id of the model (to create) based on the code
         description (str, optional): the description to set on the newly created model
-        dynamics_only (bool, optional): whether to only run the amr extraction over specified dynamics from the code object in TDS.
+        llm_assisted: (bool, optional): whether to use SKEMA's LLM assisted dynamics extraction prior to submission of a zipfile; cannot be used in conjunction with `dynamics_only`        
+        dynamics_only (bool, optional): whether to only run the amr extraction over specified dynamics from the code object in TDS; cannot be used in conjunction with `llm_assisted`
     ```
     """
     operation_name = "operations.code_to_amr"
@@ -128,6 +130,7 @@ def code_to_amr(
         "model_id": model_id,
         "description": description,
         "dynamics_only": dynamics_only,
+        "llm_assisted": llm_assisted,
     }
 
     resp = create_job(operation_name=operation_name, options=options, redis=redis)

--- a/worker/operations.py
+++ b/worker/operations.py
@@ -776,19 +776,24 @@ def code_to_amr(*args, **kwargs):
     name = kwargs.get("name")
     model_id = kwargs.get("model_id")
     description = kwargs.get("description")
+    llm_assisted = kwargs.get("llm_assisted", True)    
     dynamics_only = kwargs.get("dynamics_only", False)
 
     code_json, downloaded_code_object, dynamics_off_flag = get_code_from_tds(
         code_id, code=True, dynamics_only=dynamics_only
     )
 
-    # Checks the return flag fromm the dynamics retrieval process
+    # Checks the return flag from the dynamics retrieval process
     if dynamics_off_flag:
         dynamics_only = False
 
-    code_amr_workflow_url = f"{UNIFIED_API}/workflows/code/codebase-to-pn-amr"
+    # default to using LLM assisted extraction
+    code_amr_workflow_url = f"{UNIFIED_API}/workflows/code/llm-assisted-codebase-to-pn-amr"
+    if not llm_assisted:
+        code_amr_workflow_url = f"{UNIFIED_API}/workflows/code/codebase-to-pn-amr"
     if dynamics_only:
         code_amr_workflow_url = f"{UNIFIED_API}/workflows/code/snippets-to-pn-amr"
+
 
     if dynamics_only:
         blobs = []
@@ -822,6 +827,7 @@ def code_to_amr(*args, **kwargs):
 
     logger.info(f"Request payload: {request_payload}")
     if isinstance(request_payload, dict):
+        # dynamics only
         amr_response = requests.post(
             code_amr_workflow_url, json=json.loads(json.dumps(request_payload))
         )


### PR DESCRIPTION
Addresses #167 

@Free-Quarks note that the LLM assisted code to AMR extraction isn't explicitly tested separately but we could do so down the road. Right now the way the test harness works:

1. checks if `dynamics` exist for the code in the scenario and if so uses those
2. otherwise, it just falls back to zipfile extraction

Since #2 defaults to using the LLM assistant in our `knowledge-middleware` service it will basically just do that. We could set it up so that for a given test scenario you can "turn off LLM assistance" but then we'd need to duplicate the scenario (e.g. have 2 `SIDARTHE Code` scenarios). We'd do this by adding `llm_assisted.txt` which would just be a `bool` flag for the scenario in the scenario directory and read that into the test harness runner. Let me know what you think.